### PR TITLE
Add `-noreduce` flag if `reduce: false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = opts => buf => {
 
 	if (opts.reduce) {
 		args.push('-reduce');
+	} else {
+		args.push('-noreduce');
 	}
 
 	args.push(execBuffer.input, execBuffer.output);


### PR DESCRIPTION
As of pngcrush 1.8 and imagemin/pngcrush-bin 3.1.0 `-reduce` is enabled by default, which makes the reduce option useless right now, as no matter if `false` or `true`, it will be always enabled.

This changes the arguments to contain `-reduce` or `-noreduce`, so it works with pngcrush 1.8 or 1.7

@kevva 